### PR TITLE
Added missing parameter name to closure example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
       </div>
       <br/>
       <div>
-        applyMutliplication(2, {value <span class="func">in</span>
+        applyMutliplication(2, multFunction: {value <span class="func">in</span>
       </div>
       <div>
         &nbsp value * 3


### PR DESCRIPTION
Only the first parameter in a function can be called without using the name.
Otherwise Xcode complains about it, but provides a quick fix.

Note that this will likely cause a merge conflict with pull request #4 .
